### PR TITLE
fix: Optimize Nuitka build process in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build with Nuitka
         run: |
-          python -m nuitka --standalone --onefile --follow-imports --enable-plugin=tk-inter --windows-icon-from-ico=favicon.ico --windows-company-name="DNS Cache" --windows-product-name="DNS Cache Tool" --windows-file-version="${{ env.DATE_VERSION }}" --windows-product-version="${{ env.DATE_VERSION }}" --assume-yes-for-downloads --show-progress --show-scons --show-memory --verbose --output-dir=dist --output-filename=DNSCacheGUI gui.py
+          python -m nuitka --standalone --onefile --follow-imports --enable-plugin=tk-inter,anti-bloat --lto=yes --windows-icon-from-ico=favicon.ico --windows-company-name="DNS Cache" --windows-product-name="DNS Cache Tool" --windows-file-version="${{ env.DATE_VERSION }}" --windows-product-version="${{ env.DATE_VERSION }}" --assume-yes-for-downloads --show-progress --output-dir=dist --output-filename=DNSCacheGUI gui.py
 
       - name: Create version info
         run: |


### PR DESCRIPTION
I've optimized the Nuitka command in the GitHub Actions workflow (`.github/workflows/build.yml`) to address potential build errors and reduce the size of the generated single-file EXE.

My changes include:
- Added Link Time Optimization (`--lto=yes`).
- Enabled the `anti-bloat` Nuitka plugin to help remove unused modules.
- Streamlined build flags by removing excessive verbosity (`--show-scons`, `--show-memory`, `--verbose`) while retaining `--show-progress`.

These changes aim to produce a more compact executable and improve the reliability of the packaging process for your Tkinter GUI application.